### PR TITLE
Explicit back prop, batches, costs module

### DIFF
--- a/src/costs.rs
+++ b/src/costs.rs
@@ -1,0 +1,10 @@
+use ndarray::{ArrayView2, Zip};
+
+
+/// Determine the Mean Squared Error between `expected` and `output`
+pub fn mean_squared_error(y_true: ArrayView2<f32>, y_hat: ArrayView2<f32>) -> f32 {
+    y_true.iter()
+        .zip(y_hat.iter())
+        .map(|(yt, yh)| (yt - yh).powf(2.0))
+        .sum::<f32>() / y_true.rows() as f32
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-
 pub mod layers;
 pub mod network;
 pub mod activations;
+pub mod costs;

--- a/src/network.rs
+++ b/src/network.rs
@@ -22,7 +22,7 @@ impl Sequential {
     pub fn new() -> Self {
         let mut nn = Sequential::default();
         nn.lr = 0.1;
-        nn.n_epoch = 100;
+        nn.n_epoch = 10;
         nn.batch_size = 32;
         nn
     }
@@ -46,8 +46,8 @@ impl Sequential {
     }
 
     /// Use the network to predict the outcome of x
-    pub fn predict(&mut self, x: Array2<f32>) -> Array2<f32> {
-        self.forward(x.view())
+    pub fn predict(&mut self, x: ArrayView2<f32>) -> Array2<f32> {
+        self.forward(x)
     }
     
     /// Apply the network against an input
@@ -87,10 +87,10 @@ impl Sequential {
     }
 
     /// Train the network according to the parameters set given training and target data
-    pub fn fit(&mut self, x: Array2<f32>, y: Array2<f32>) {
+    pub fn fit(&mut self, x: ArrayView2<f32>, y: ArrayView2<f32>) {
 
         // Epochs
-        for epoch in 0..self.n_epoch {
+        for _epoch in 0..self.n_epoch {
 
             // Batches
             for (batch, target) in x.exact_chunks((self.batch_size, x.shape()[1]))

--- a/tests/test_costs.rs
+++ b/tests/test_costs.rs
@@ -1,0 +1,16 @@
+use ndarray::arr2;
+
+use pyrus_nn::costs;
+
+#[test]
+fn test_mse() {
+    let y_true = arr2(&[
+        [1.], [2.], [3.]
+    ]);
+    let y_hat = arr2(&[
+        [1.], [0.5], [3.5]
+    ]);
+
+    let error = costs::mean_squared_error(y_true.view(), y_hat.view());
+    assert_eq!(error, 0.833333333);
+}


### PR DESCRIPTION
Adds:

- Explicit `backward` method to match `forward`
- Batch training
- costs module
- use `mean_squared_error` in network test